### PR TITLE
Number of items in pagination does not break page design

### DIFF
--- a/src/components/DriversList/index.jsx
+++ b/src/components/DriversList/index.jsx
@@ -208,6 +208,7 @@ export default class DriversList extends Component {
 
     return (
       <div>
+        <h2 className="text-center my-4">Taxistas</h2>
         <div>
           <input type="text" placeholder="Buscar..." className="search" value={this.state.searchValue} onChange={evt => this.matchDrivers(evt.target.value)} ></input>
         </div>

--- a/src/components/OrganizationsList/index.jsx
+++ b/src/components/OrganizationsList/index.jsx
@@ -144,7 +144,7 @@ export default class DriversList extends Component {
     return (
       <div>
         <div className="topMargin">
-          <h2>Sitios</h2>
+          <h2 className="text-center my-4">Sitios</h2>
           <div className="taxiSitesCreateDiv">
             <input type="text" placeholder="Crear un sitio...." className="siteNameInput" value={this.state.siteName} onChange={(evt) => this.setState({siteName: evt.target.value})}></input>
             <button type="button" className="createBtn" onClick={() => this.createOrganization()}>Crear</button>

--- a/src/components/ServicesList/index.jsx
+++ b/src/components/ServicesList/index.jsx
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import './servicesList.css'
 import { Table } from 'reactstrap';
 import Api from '../../utils/api';
 import Item from './Item';
@@ -93,7 +94,7 @@ export default class ServicesList extends Component {
     const {services, errors, flash, pageCount, selectedPage} = this.state;
     return(
       <div>
-        <h2>Taxistas</h2>
+        <h2 className="text-center my-4">Tipos de servicios</h2>
         {errors && <AlertMessage message={alert.message}/>}
         {flash && <AlertMessage alertType={flash.type} message={flash.message}/>}
         <div>

--- a/src/components/ServicesList/servicesList.css
+++ b/src/components/ServicesList/servicesList.css
@@ -1,0 +1,5 @@
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/components/TripsList/index.jsx
+++ b/src/components/TripsList/index.jsx
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import './tripList.css'
 import { Table } from 'reactstrap';
 import Api from '../../utils/api';
 import { init, instance } from '../../firebase'
@@ -138,16 +139,16 @@ export default class TripsList extends Component {
     const {trips, errors, flash, pageCount, selectedPage, status} = this.state;
     return(
       <div>
-        <h2>Servicios activos</h2>
-        <div>
-          <select name="" id="" onChange={this.onStatusChange} value={status}>
+        <h2 className="text-center my-4">Servicios</h2>
+        <div className="form-inline mb-2">
+          <select name="" id="" onChange={this.onStatusChange} value={status} className="form-control">
             <option value="holding">En espera</option>
             <option value="finished">Finalizados</option>
             {/*<option value="taken">Tomado</option>*/}
             <option value="active">Activo/Tomado</option>
             <option value="canceled">Cancelado</option>
           </select>
-          <button onClick={this.logTimes}>
+          <button onClick={this.logTimes} className="btn btn-outline-dark ml-2">
             Log tiempos
           </button>
         </div>
@@ -182,17 +183,19 @@ export default class TripsList extends Component {
             <PaginationItem>
               <PaginationLink previous onClick={this.previousItem}/>
             </PaginationItem>
-            {
-              new Array(pageCount).fill(0).map((val, index) => {
-                return(
-                  <PaginationItem key={index} active={index + 1 === selectedPage}>
-                    <PaginationLink data-page={index + 1} onClick={this.getPage}>
-                      {index + 1}
-                    </PaginationLink>
-                  </PaginationItem>
-                )
-              })
-            }
+            <div className="horizontal-scrolable">
+              {
+                new Array(pageCount).fill(0).map((val, index) => {
+                  return(
+                    <PaginationItem key={index} active={index + 1 === selectedPage}>
+                      <PaginationLink data-page={index + 1} onClick={this.getPage}>
+                        {index + 1}
+                      </PaginationLink>
+                    </PaginationItem>
+                  )
+                })
+              }
+            </div>
             <PaginationItem>
               <PaginationLink next onClick={this.nextItem}/>
             </PaginationItem>

--- a/src/components/TripsList/tripList.css
+++ b/src/components/TripsList/tripList.css
@@ -1,0 +1,9 @@
+.pagination {
+  width: 100%;
+}
+
+.horizontal-scrolable {
+  display: flex;
+  overflow: scroll;
+  widows: 100%;
+}

--- a/src/components/UsersList/index.jsx
+++ b/src/components/UsersList/index.jsx
@@ -8,7 +8,7 @@ export default class UsersList extends Component {
 
   constructor () {
     super()
-    this.state = { 
+    this.state = {
       users: [],
       pages: 0,
       currentPage: 0,
@@ -27,7 +27,7 @@ export default class UsersList extends Component {
     if (opcion === true) {
       this.deleteUser(usrId)
     }
-  } 
+  }
 
   fetchUsers () {
     this.setState({ loading: true });
@@ -46,7 +46,7 @@ export default class UsersList extends Component {
           errors: err.response.data.errors
         })
       });
-  } 
+  }
 
   editUser = (usrId) => {
     const path = `/user/${usrId}`
@@ -99,9 +99,9 @@ export default class UsersList extends Component {
       }, () => {
         this.fetchUsers()
       })
-    } 
+    }
   }
-  
+
   formatUsersForTable = (users) => {
     var data = [];
     data = users.map(user => {
@@ -119,7 +119,7 @@ export default class UsersList extends Component {
 
   handlePage(page) {
     this.setState({
-      currentPage: page 
+      currentPage: page
     }, () => {
       if(this.state.searchValue.length !== 0 && this.state.searchValue !== ' '){
         this.matchUsers(this.state.searchValue)
@@ -151,6 +151,7 @@ export default class UsersList extends Component {
     ]
     return(
       <div>
+        <h2 className="text-center my-4">Usuarios</h2>
         <div>
           <input type="text" placeholder="Buscar..." className="search" value={this.state.searchValue} onChange={evt => this.matchUsers(evt.target.value)} ></input>
         </div>

--- a/src/sharedComponents/Navbar/index.jsx
+++ b/src/sharedComponents/Navbar/index.jsx
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import { Link } from 'react-router-dom'
+import { Link, withRouter } from 'react-router-dom'
 import {
   Collapse,
   Navbar,
@@ -14,7 +14,7 @@ import {
   DropdownItem } from 'reactstrap';
 import './NavbarStyles.css';
 
-export default class NavigationBar extends Component {
+class NavigationBar extends Component {
   constructor(props) {
     super(props);
 
@@ -34,27 +34,30 @@ export default class NavigationBar extends Component {
       <Navbar className="header" light expand="md">
         <NavbarBrand className="appTitle" href="/">Cytio Admin</NavbarBrand>
         <NavbarToggler id={'toggle'} onClick={this.toggle} />
-        <Collapse isOpen={this.state.isOpen} navbar>
-          <Nav className="ml-auto" navbar>
-            <NavItem>
-              <NavLink id='link' tag={Link} to="/users">Usuarios</NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink id='link' tag={Link} to="/drivers">Taxistas</NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink id='link' tag={Link} to="/organizations">Sitios</NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink id='link' tag={Link} to="/services">Tipo de Servicio</NavLink>
-            </NavItem>
-            <NavItem>
-              <NavLink id='link' tag={Link} to="/trips">Servicios Activos</NavLink>
-            </NavItem>
-          </Nav>
-        </Collapse>
+        { this.props.location.pathname != '/' &&
+          <Collapse isOpen={this.state.isOpen} navbar>
+            <Nav className="ml-auto" navbar>
+              <NavItem>
+                <NavLink id='link' tag={Link} to="/users">Usuarios</NavLink>
+              </NavItem>
+              <NavItem>
+                <NavLink id='link' tag={Link} to="/drivers">Taxistas</NavLink>
+              </NavItem>
+              <NavItem>
+                <NavLink id='link' tag={Link} to="/organizations">Sitios</NavLink>
+              </NavItem>
+              <NavItem>
+                <NavLink id='link' tag={Link} to="/services">Tipo de Servicio</NavLink>
+              </NavItem>
+              <NavItem>
+                <NavLink id='link' tag={Link} to="/trips">Servicios Activos</NavLink>
+              </NavItem>
+            </Nav>
+          </Collapse>
+        }
       </Navbar>
     )
   }
 }
 
+export default withRouter(NavigationBar)


### PR DESCRIPTION
Since the number of pages in the list of services was bigger than the available page space, they used to push the width page size.
Now items are inside a scrollable container, so they can increase and keep a regular size.

<img width="1104" alt="Screen Shot 2019-07-23 at 11 34 47 AM" src="https://user-images.githubusercontent.com/26292224/61730564-42fe0780-ad3f-11e9-88d7-1c7578d5dcf7.png">


Section title was added on each option, and navbar options where removed from the main page, since it already shows up all the available options.

<img width="1104" alt="Screen Shot 2019-07-23 at 11 35 22 AM" src="https://user-images.githubusercontent.com/26292224/61730098-4775f080-ad3e-11e9-9863-07a97da6aa05.png">
